### PR TITLE
Add checkout modal with player info collection

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,50 @@
     </div>
   </aside>
 
-  
+  <!-- Checkout modal -->
+  <div id="checkout-modal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-panel">
+      <button type="button" class="modal-close" id="close-modal" aria-label="Close">✕</button>
+      <h3>Complete Your Order</h3>
+      <p class="modal-lead">
+        Before paying, please make sure you have opened a complaint/support ticket if you faced any issues.
+        We also need your in-game details so staff can deliver your keys quickly after payment.
+      </p>
+      <form id="checkout-form" class="modal-form">
+        <label class="field">
+          <span>Minecraft Username</span>
+          <input type="text" id="minecraft-name" name="minecraft" autocomplete="username" placeholder="Ex: Notch" required />
+        </label>
+        <label class="field">
+          <span>Discord Username</span>
+          <input type="text" id="discord-name" name="discord" autocomplete="off" placeholder="Ex: Player#1234" required />
+        </label>
+        <label class="field">
+          <span>Complaint / Ticket Status</span>
+          <select id="complaint-status" name="complaint" required>
+            <option value="" disabled selected>Select an option</option>
+            <option value="no-issue">No complaints, I'm ready to pay.</option>
+            <option value="submitted">I already opened a ticket about an issue.</option>
+            <option value="need-help">I still need help before paying.</option>
+          </select>
+        </label>
+        <p id="checkout-message" class="modal-message" role="alert" aria-live="polite"></p>
+        <button type="submit" class="btn btn-wide">Review Order &amp; Pay</button>
+      </form>
+      <section id="checkout-summary" class="modal-summary" hidden>
+        <h4>Order Summary</h4>
+        <ul id="summary-items"></ul>
+        <p class="summary-total">Total: <span id="summary-total"></span></p>
+        <p class="summary-note">
+          Copy the order details and share them in your Discord ticket. Our team will process the payment with you and deliver the keys manually after confirming your Minecraft and Discord names.
+        </p>
+        <div class="summary-actions">
+          <button type="button" class="btn btn-ghost" id="copy-order">Copy Order Details</button>
+          <a class="btn" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener">Open Discord Ticket</a>
+        </div>
+      </section>
+    </div>
+  </div>
 
   <script src="assets/panel.js"></script>
   <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,40 @@ img{max-width:100%;height:auto;user-select:none;pointer-events:none}
 .cart-buttons{display:flex;gap:10px}
 .total{font-weight:800;font-size:18px}
 
+/* Modal */
+.modal{
+  position:fixed;inset:0;display:flex;align-items:center;justify-content:center;
+  padding:24px;background:rgba(8,6,15,0.84);backdrop-filter:blur(8px);
+  opacity:0;pointer-events:none;visibility:hidden;transition:opacity .25s ease;
+  z-index:80;
+}
+.modal.open{opacity:1;pointer-events:auto;visibility:visible;}
+.modal-panel{
+  width:min(480px,92%);background:#120f1c;border:1px solid #ffffff18;border-radius:20px;
+  box-shadow:0 30px 60px #000c;padding:26px;display:grid;gap:18px;position:relative;
+}
+.modal-close{
+  position:absolute;top:14px;right:14px;background:#1f1a2b;color:#fff;border:1px solid #ffffff22;
+  border-radius:10px;padding:6px 10px;cursor:pointer;font-size:16px;
+}
+.modal-lead{margin:0;color:var(--muted);line-height:1.5}
+.modal-form{display:grid;gap:14px}
+.field{display:grid;gap:6px;font-size:14px;color:var(--muted)}
+.field input,.field select{
+  background:#00000055;color:var(--text);border:1px solid #ffffff22;border-radius:10px;
+  padding:10px 12px;font-size:15px;
+}
+.btn-wide{width:100%;justify-content:center;display:inline-flex}
+.modal-message{min-height:18px;font-size:13px;color:#fca5a5;margin:0}
+.modal-summary{display:grid;gap:12px;border-top:1px solid #ffffff12;padding-top:12px}
+.modal-summary[hidden]{display:none}
+.modal-summary h4{margin:0;font-size:18px}
+#summary-items{list-style:none;margin:0;padding:0;display:grid;gap:8px;font-size:14px;color:var(--muted)}
+.summary-total{margin:0;font-weight:700}
+.summary-note{margin:0;color:var(--muted);font-size:13px;line-height:1.5}
+.summary-actions{display:flex;gap:12px;flex-wrap:wrap}
+.summary-actions .btn{flex:1;min-width:150px;text-align:center}
+
 /* Footer */
 .footer{display:flex;justify-content:space-between;align-items:center;margin:28px 0 40px 0;padding-top:14px;border-top:1px solid #ffffff12}
 a{text-decoration:none;color:inherit}


### PR DESCRIPTION
## Summary
- add a checkout modal to collect Minecraft/Discord usernames and ticket status before payment
- generate an order summary with copy-to-clipboard details and Discord ticket link
- style the modal for consistency with the existing theme and integrate the new checkout workflow in script.js

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68defcebe89883248ae1e31712eae1af