### PR TITLE
Improve mobile header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,11 @@
         <span class="logo">🔑</span>
         <h1>ArabSMP</h1>
       </div>
-      <nav class="nav">
+      <button class="menu-toggle" id="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="sr-only">Toggle navigation</span>
+      </button>
+      <nav class="nav" id="primary-nav">
         <a class="btn btn-discord" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener">Join Discord</a>
         <button id="copy-ip" class="btn btn-ghost" aria-label="Copy server IP">Copy IP</button>
         <button id="theme-toggle" class="btn btn-ghost theme-toggle" type="button" aria-pressed="true" aria-label="Switch to light mode">

--- a/script.js
+++ b/script.js
@@ -8,6 +8,33 @@ const $$ = (sel, ctx=document) => [...ctx.querySelectorAll(sel)];
 const fmt = n => '$' + (Math.round(n * 100) / 100).toFixed(2);
 
 const themeToggle = $('#theme-toggle');
+const menuToggle = $('#menu-toggle');
+const primaryNav = $('#primary-nav');
+
+if(menuToggle && primaryNav){
+  document.body.classList.add('menu-enhanced');
+  const closeMenu = () => {
+    primaryNav.classList.remove('is-open');
+    menuToggle.classList.remove('is-active');
+    menuToggle.setAttribute('aria-expanded', 'false');
+  };
+
+  menuToggle.addEventListener('click', () => {
+    const isOpen = !primaryNav.classList.contains('is-open');
+    primaryNav.classList.toggle('is-open', isOpen);
+    menuToggle.classList.toggle('is-active', isOpen);
+    menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  });
+
+  $$('#primary-nav a, #primary-nav button').forEach(el => {
+    el.addEventListener('click', () => closeMenu());
+  });
+
+  const mq = window.matchMedia('(min-width: 768px)');
+  mq.addEventListener('change', e => { if(e.matches) closeMenu(); });
+
+  closeMenu();
+}
 
 function applyTheme(theme, { persist = true, animate = true } = {}){
   const next = theme === 'light' ? 'light' : 'dark';

--- a/styles.css
+++ b/styles.css
@@ -162,6 +162,18 @@ img { max-width:100%; height:auto; display:block; user-select:none; }
 
 a { color:inherit; text-decoration:none; }
 
+.sr-only {
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
+
 .container { width:min(1120px, 92%); margin-inline:auto; }
 
 main { display:grid; gap:96px; padding:48px 0 120px; }
@@ -219,6 +231,59 @@ section { position:relative; }
 .header h1 { margin:0; font-size:20px; letter-spacing:.4px; font-weight:800; }
 
 .nav { display:flex; align-items:center; gap:12px; flex-wrap:wrap; justify-content:flex-end; }
+
+.menu-toggle {
+  display:none;
+  align-items:center;
+  justify-content:center;
+  width:42px;
+  height:42px;
+  border-radius:12px;
+  border:1px solid var(--surface-border);
+  background:var(--surface-glass);
+  color:var(--text);
+  cursor:pointer;
+  transition:background .25s ease, border-color .25s ease, transform .25s ease;
+}
+
+.menu-toggle:hover { background:var(--surface-glass-hover); }
+
+.menu-toggle:focus-visible {
+  outline:2px solid var(--outline-border);
+  outline-offset:3px;
+}
+
+.menu-icon,
+.menu-icon::before,
+.menu-icon::after {
+  display:block;
+  width:18px;
+  height:2px;
+  border-radius:999px;
+  background:currentColor;
+  transition:transform .3s ease, opacity .3s ease;
+  transform-origin:center;
+}
+
+.menu-icon { position:relative; }
+
+.menu-icon::before,
+.menu-icon::after {
+  content:"";
+  position:absolute;
+  left:0;
+}
+
+.menu-icon::before { top:-6px; }
+
+.menu-icon::after { top:6px; }
+
+.menu-toggle.is-active .menu-icon { background:transparent; }
+
+.menu-toggle.is-active .menu-icon::before { transform:translateY(6px) rotate(45deg); }
+
+.menu-toggle.is-active .menu-icon::after { transform:translateY(-6px) rotate(-45deg); }
+
 
 /* Buttons --------------------------------------------------------------- */
 .btn {
@@ -994,10 +1059,46 @@ section { position:relative; }
   .page-header { position:sticky; }
 }
 
+@media (max-width:768px) {
+  .page-header {
+    position:static;
+    top:auto;
+  }
+
+  .header {
+    padding:12px 0;
+    gap:12px;
+    flex-wrap:wrap;
+  }
+
+  .brand { flex:1; }
+
+  .header h1 { font-size:18px; }
+
+  .menu-toggle { display:inline-flex; }
+
+  body.menu-enhanced .nav {
+    width:100%;
+    flex-basis:100%;
+    display:none;
+    flex-direction:column;
+    align-items:stretch;
+    gap:10px;
+    padding-top:8px;
+  }
+
+  body.menu-enhanced .nav.is-open {
+    display:flex;
+  }
+
+  body.menu-enhanced .nav .btn {
+    width:100%;
+  }
+}
+
 @media (max-width:640px) {
   main { gap:72px; padding:32px 0 90px; }
-  .header { flex-direction:column; align-items:flex-start; }
-  .nav { width:100%; justify-content:flex-start; }
+  .header { align-items:center; }
   .hero-logo { width:min(300px, 70vw); }
   .hero-note { flex-direction:column; align-items:flex-start; }
   .hero-steps li { align-items:flex-start; }


### PR DESCRIPTION
## Summary
- add a hamburger toggle so the navigation collapses on small screens
- allow the header to scroll with the page and tighten padding for mobile viewports
- wire up menu interactions in JavaScript and add accessible helper styles

## Testing
- Manual check in a mobile viewport via Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68df472fc3808324be49870c767124a2