### PR TITLE
Add dynamic language toggle with translation support

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,16 +21,23 @@
     <div class="container header reveal" data-animate="fade-down">
       <div class="brand">
         <span class="logo">🔑</span>
-        <h1>ArabSMP</h1>
+        <h1 data-i18n="brand.name">ArabSMP</h1>
       </div>
-      <nav class="nav">
-        <a class="btn btn-discord" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener">Join Discord</a>
-        <button id="copy-ip" class="btn btn-ghost" aria-label="Copy server IP">Copy IP</button>
-        <button id="theme-toggle" class="btn btn-ghost theme-toggle" type="button" aria-pressed="true" aria-label="Switch to light mode">
+      <button class="menu-toggle" id="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="sr-only">Toggle navigation</span>
+      </button>
+      <nav class="nav" id="primary-nav">
+        <a class="btn btn-discord" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener" data-i18n="nav.joinDiscord">Join Discord</a>
+        <button id="copy-ip" class="btn btn-ghost" aria-label="Copy server IP" data-i18n="nav.copyIp" data-i18n-aria-label="nav.copyIpAria">Copy IP</button>
+        <button id="theme-toggle" class="btn btn-ghost theme-toggle" type="button" aria-pressed="true" aria-label="Switch to light mode" data-i18n-aria-label="nav.themeAriaLight">
           <span class="theme-icon" aria-hidden="true">🌙</span>
-          <span class="theme-text">Dark</span>
+          <span class="theme-text" data-i18n="nav.themeDark">Dark</span>
         </button>
-        <button id="open-cart" class="btn btn-cart" aria-label="Open cart">Cart <span id="cart-count">0</span></button>
+        <button id="language-toggle" class="btn btn-ghost language-toggle" type="button" aria-label="Switch to Arabic" data-i18n-aria-label="nav.languageSwitchAr">
+          <span class="language-toggle-text">AR</span>
+        </button>
+        <button id="open-cart" class="btn btn-cart" aria-label="Open cart" data-i18n="nav.cart" data-i18n-aria-label="nav.cartAria">Cart <span id="cart-count">0</span></button>
       </nav>
     </div>
   </header>
@@ -47,29 +54,29 @@
               loading="lazy"
             />
           </div>
-          <p class="eyebrow">Official ArabSMP Store</p>
-          <h2>Get Your Keys &amp; Support the Server</h2>
-          <p>
+          <p class="eyebrow" data-i18n="hero.eyebrow">Official ArabSMP Store</p>
+          <h2 data-i18n="hero.heading">Get Your Keys &amp; Support the Server</h2>
+          <p data-i18n="hero.description">
             Unlock premium gear, fund new events, and help the community grow stronger with every purchase.
             Our staff team is ready to hand-deliver your keys so you can jump right back into the adventure.
           </p>
-          <ul class="hero-steps" aria-label="How the process works">
-            <li><span>1</span>Choose your key pack and add it to the cart.</li>
-            <li><span>2</span>Provide your <strong>Minecraft</strong> and <strong>Discord</strong> names at checkout.</li>
-            <li><span>3</span>Join the <strong>🔑│key-delivery-wait</strong> channel on Discord for fast manual delivery.</li>
+          <ul class="hero-steps" aria-label="How the process works" data-i18n-aria-label="hero.stepsAria">
+            <li data-i18n-html="hero.step1"><span>1</span>Choose your key pack and add it to the cart.</li>
+            <li data-i18n-html="hero.step2"><span>2</span>Provide your <strong>Minecraft</strong> and <strong>Discord</strong> names at checkout.</li>
+            <li data-i18n-html="hero.step3"><span>3</span>Join the <strong>🔑│key-delivery-wait</strong> channel on Discord for fast manual delivery.</li>
           </ul>
           <div class="hero-actions">
             <div class="ip-box">
               <code id="server-ip">ArabSMP.mcserver.us</code>
-              <button class="btn small" id="copy-ip-hero">Copy</button>
+              <button class="btn small" id="copy-ip-hero" data-i18n="hero.copy">Copy</button>
             </div>
-            <a class="btn btn-outline" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener">Open Discord</a>
+            <a class="btn btn-outline" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener" data-i18n="hero.openDiscord">Open Discord</a>
           </div>
-          <div class="hero-note">
+          <div class="hero-note" data-i18n-html="hero.note">
             <span class="tag">Manual delivery</span>
             We usually respond within minutes. If you need help, message <strong>Telegram: m7mdd_x</strong> or open a ticket in Discord.
           </div>
-          <p class="hero-hint"><em>Automatic delivery is coming soon — you’ll only need to enter your Minecraft username.</em></p>
+          <p class="hero-hint" data-i18n-html="hero.hint"><em>Automatic delivery is coming soon — you’ll only need to enter your Minecraft username.</em></p>
         </div>
         <div class="hero-visual" aria-hidden="true">
           <div class="hero-glow"></div>
@@ -79,8 +86,8 @@
             <img src="assets/keys/key-blue.svg" alt="" class="hero-img hero-img-tertiary" />
           </div>
           <div class="hero-stat-card">
-            <p>Trusted by <strong>thousands</strong> of players keeping the realm alive.</p>
-            <div class="stat-pulse">Live Support Online</div>
+            <p data-i18n-html="hero.stat">Trusted by <strong>thousands</strong> of players keeping the realm alive.</p>
+            <div class="stat-pulse" data-i18n="hero.supportStatus">Live Support Online</div>
           </div>
         </div>
       </div>
@@ -91,18 +98,18 @@
         <div class="feature-grid reveal" data-animate="fade-up">
           <article class="feature-card">
             <span class="feature-icon">⚡</span>
-            <h3>Fast Staff Response</h3>
-            <p>Our moderators monitor the delivery channel to make sure you receive your keys without delays.</p>
+            <h3 data-i18n="features.fastTitle">Fast Staff Response</h3>
+            <p data-i18n="features.fastCopy">Our moderators monitor the delivery channel to make sure you receive your keys without delays.</p>
           </article>
           <article class="feature-card">
             <span class="feature-icon">🛡️</span>
-            <h3>Secure Checkout</h3>
-            <p>Every order is confirmed manually, giving you peace of mind and accurate delivery of your rewards.</p>
+            <h3 data-i18n="features.secureTitle">Secure Checkout</h3>
+            <p data-i18n="features.secureCopy">Every order is confirmed manually, giving you peace of mind and accurate delivery of your rewards.</p>
           </article>
           <article class="feature-card">
             <span class="feature-icon">🎉</span>
-            <h3>Community Powered</h3>
-            <p>Your purchase supports events, content drops, and improvements for the entire ArabSMP community.</p>
+            <h3 data-i18n="features.communityTitle">Community Powered</h3>
+            <p data-i18n="features.communityCopy">Your purchase supports events, content drops, and improvements for the entire ArabSMP community.</p>
           </article>
         </div>
       </div>
@@ -111,13 +118,13 @@
     <section class="catalog-section">
       <div class="container">
         <div class="section-heading reveal" data-animate="fade-up">
-          <p class="eyebrow">Key Collection</p>
-          <h2>Choose the Pack That Fits Your Journey</h2>
-          <p>Every key unlocks exclusive gear and helps fund server upgrades. Mix and match the packs below.</p>
+          <p class="eyebrow" data-i18n="catalog.eyebrow">Key Collection</p>
+          <h2 data-i18n="catalog.heading">Choose the Pack That Fits Your Journey</h2>
+          <p data-i18n="catalog.description">Every key unlocks exclusive gear and helps fund server upgrades. Mix and match the packs below.</p>
         </div>
         <div class="grid reveal" data-animate="fade-up" data-delay="0.05s">
           <!-- Product Cards -->
-          <div class="card tilt" data-id="key-green" data-name="Common Key" data-price="1.23"
+          <div class="card tilt" data-id="key-green" data-name="Common Key" data-name-key="products.common.name" data-price="1.23"
             data-img="assets/keys/key-green.svg" data-kp-img="assets/previews/common.png"
             data-kp-title="Common"
             data-kp-desc="Choose 1 of the following enchanted diamond gear:<br>
@@ -131,38 +138,31 @@
 
             <img src="assets/keys/key-green.svg" alt="Common Key" draggable="false"  data-kp-img="assets/previews/common.png" data-kp-title="Common"data-kp-desc="Choose 1 of the following enchanted diamond gear:<br>- Diamond Helmet (Protection I, Respiration II, Aqua Affinity, +400% Submerged Mining Speed, +2 Oxygen Bonus)<br>- Diamond Chestplate (Protection I, +8 Armor, +2 Armor Toughness)<br>- Diamond Leggings (Protection I, Swift Sneak II, +0.3 Sneaking Speed)<br>- Diamond Boots (Protection I, Feather Falling II, Depth Strider II, +0.67 Water Movement Efficiency)<br>- Diamond Sword (Sharpness I, Looting II, 7 Attack Damage, 1.6 Attack Speed)<br>- Diamond Pickaxe (Fortune I, Efficiency II, +5 Mining Efficiency)<br>- Diamond Shovel (Efficiency III, 5.5 Attack Damage, 1 Attack Speed, +10 Mining Efficiency)">
 
-            <h3>Common Key</h3>
+            <h3 data-i18n="products.common.name">Common Key</h3>
             <p class="price">$1.23</p>
             <div class="actions">
-              <label>Qty</label>
+              <label data-i18n="products.quantity">Qty</label>
               <select class="qty">
                 <option>1</option><option>3</option><option>5</option><option>10</option>
               </select>
-              <button class="btn add">Add</button>
+              <button class="btn add" data-i18n="products.add">Add</button>
             </div>
           </div>
 
-          <div class="card tilt" data-id="key-blue" data-name="Prime Key" data-price="3.65" data-img="assets/keys/key-blue.svg" data-kp-img="assets/previews/prime.png" data-kp-title="Prime" data-kp-desc="Choose 1 of the following upgraded netherite items:<br>
-- Netherite Helmet (Protection IV, Respiration III, Aqua Affinity, Unbreaking III, Mending, +400% Submerged Mining Speed, +3 Oxygen Bonus)<br>
-- Netherite Chestplate (Protection IV, Unbreaking III, Mending, +8 Armor, +3 Armor Toughness, +1 Knockback Resistance)<br>
-- Netherite Leggings (Blast Protection IV, Swift Sneak III, Unbreaking III, Mending, +0.45 Sneaking Speed, +0.6 Explosion Knockback Resistance)<br>
-- Netherite Boots (Protection IV, Feather Falling IV, Soul Speed III, Depth Strider III, Unbreaking III, Mending, +1 Water Movement Efficiency)<br>
-- Netherite Sword (Sharpness V, Sweeping Edge III, Knockback I, Looting III, Unbreaking III, Mending, 8 Attack Damage, 1.6 Attack Speed)<br>
-- Crossbow (Multishot, Quick Charge III, Unbreaking III, Mending)<br>
-- Mace (Breach IV, Unbreaking III, Mending, 6 Attack Damage, 0.6 Attack Speed)">
-            <img src="assets/keys/key-blue.svg" alt="Prime Key" draggable="false"  data-kp-img="assets/previews/prime.png" data-kp-title="Prime" data-kp-desc="Choose one upgraded item. Better odds than Common." />
-            <h3>Prime Key</h3>
+            <div class="card tilt" data-id="key-blue" data-name="Prime Key" data-name-key="products.prime.name" data-price="3.65" data-img="assets/keys/key-blue.svg" data-kp-img="assets/previews/prime.png" data-kp-title="Prime" data-kp-desc="Choose 1 of the following upgraded items:<br><br>- Netherite Helmet (Protection V, Respiration III, Aqua Affinity, Unbreaking III, Mending, +400% Submerged Mining Speed, +3 Oxygen Bonus)<br>- Netherite Chestplate (Protection V, Unbreaking III, Mending, +200% Explosion Knockback Resistance)<br>- Netherite Leggings (Protection V, Unbreaking III, Mending, +150% Sprint Speed)<br>- Netherite Boots (Protection V, Depth Strider III, Feather Falling IV, Unbreaking III, Mending, +200% Speed in Water)<br>- Netherite Sword (Sharpness V, Sweeping Edge III, Knockback I, Looting III, Mending, Unbreaking III, 8 Attack Damage, 1.6 Attack Speed)<br>- Netherite Pickaxe (Efficiency V, Fortune III, Unbreaking III, Mending, +200% Mining Speed)<br>- Netherite Axe (Efficiency V, Sharpness V, Unbreaking III, Mending, +150% Attack Damage)<br>- Netherite Crossbow (Quick Charge III, Multishot, Unbreaking III, Mending)<br>- Netherite Mace (Knockback II, Sharpness V, Unbreaking III, Mending, 12 Attack Damage)">
+            <img src="assets/keys/key-blue.svg" alt="Prime Key" draggable="false"  data-kp-img="assets/previews/prime.png" data-kp-title="Prime" data-kp-desc="Choose 1 of the following upgraded items:<br><br>- Netherite Helmet (Protection V, Respiration III, Aqua Affinity, Unbreaking III, Mending, +400% Submerged Mining Speed, +3 Oxygen Bonus)<br>- Netherite Chestplate (Protection V, Unbreaking III, Mending, +200% Explosion Knockback Resistance)<br>- Netherite Leggings (Protection V, Unbreaking III, Mending, +150% Sprint Speed)<br>- Netherite Boots (Protection V, Depth Strider III, Feather Falling IV, Unbreaking III, Mending, +200% Speed in Water)<br>- Netherite Sword (Sharpness V, Sweeping Edge III, Knockback I, Looting III, Mending, Unbreaking III, 8 Attack Damage, 1.6 Attack Speed)<br>- Netherite Pickaxe (Efficiency V, Fortune III, Unbreaking III, Mending, +200% Mining Speed)<br>- Netherite Axe (Efficiency V, Sharpness V, Unbreaking III, Mending, +150% Attack Damage)<br>- Netherite Crossbow (Quick Charge III, Multishot, Unbreaking III, Mending)<br>- Netherite Mace (Knockback II, Sharpness V, Unbreaking III, Mending, 12 Attack Damage)" />
+            <h3 data-i18n="products.prime.name">Prime Key</h3>
             <p class="price">$3.65</p>
             <div class="actions">
-              <label>Qty</label>
+              <label data-i18n="products.quantity">Qty</label>
               <select class="qty">
                 <option>1</option><option>3</option><option selected>5</option><option>10</option>
               </select>
-              <button class="btn add">Add</button>
+              <button class="btn add" data-i18n="products.add">Add</button>
             </div>
           </div>
 
-          <div class="card tilt" data-id="key-gold" data-name="Gold Key" data-price="5.02" data-img="assets/keys/key-gold.svg" data-kp-img="assets/previews/gold.png" data-kp-title="Gold" data-kp-desc="Choose 1 of the following mob spawners:<br>
+          <div class="card tilt" data-id="key-gold" data-name="Gold Key" data-name-key="products.gold.name" data-price="5.02" data-img="assets/keys/key-gold.svg" data-kp-img="assets/previews/gold.png" data-kp-title="Gold" data-kp-desc="Choose 1 of the following mob spawners:<br><br>
 - Cow Spawner: Exp +3 | Drops 1-3 Raw Beef, 0-2 Leather<br>
 - Spider Spawner: Exp +5 | Drops 1 Spider Eye, 0-2 String<br>
 - Zombie Spawner: Exp +5 | Drops 1 Carrot, 1 Iron Ingot, 1 Potato, 0-2 Rotten Flesh<br>
@@ -170,32 +170,32 @@
 - Blaze Spawner: Exp +10 | Drops 0-1 Blaze Rod<br>
 - Creeper Spawner: Exp +5 | Drops 0-2 Gunpowder<br>
 - Iron Golem Spawner: Exp +0 | Drops 3-5 Iron Ingots, 0-2 Poppies">
-            <img src="assets/keys/key-gold.svg" alt="Gold Key" draggable="false"  data-kp-img="assets/previews/gold.png" data-kp-title="Gold" data-kp-desc="Choose one high-tier item." />
-            <h3>Gold Key</h3>
+            <img src="assets/keys/key-gold.svg" alt="Gold Key" draggable="false"  data-kp-img="assets/previews/gold.png" data-kp-title="Gold" data-kp-desc="Choose 1 of the following mob spawners:<br><br>- Cow Spawner: Exp +3 | Drops 1-3 Raw Beef, 0-2 Leather<br>- Spider Spawner: Exp +5 | Drops 1 Spider Eye, 0-2 String<br>- Zombie Spawner: Exp +5 | Drops 1 Carrot, 1 Iron Ingot, 1 Potato, 0-2 Rotten Flesh<br>- Skeleton Spawner: Exp +5 | Drops 0-2 Arrows, 0-2 Bones, 1 Bow<br>- Blaze Spawner: Exp +10 | Drops 0-1 Blaze Rod<br>- Creeper Spawner: Exp +5 | Drops 0-2 Gunpowder<br>- Iron Golem Spawner: Exp +0 | Drops 3-5 Iron Ingots, 0-2 Poppies" />
+            <h3 data-i18n="products.gold.name">Gold Key</h3>
             <p class="price">$5.02</p>
             <div class="actions">
-              <label>Qty</label>
+              <label data-i18n="products.quantity">Qty</label>
               <select class="qty">
                 <option>1</option><option>3</option><option>5</option><option selected>10</option>
               </select>
-              <button class="btn add">Add</button>
+              <button class="btn add" data-i18n="products.add">Add</button>
             </div>
           </div>
 
-          <div class="card tilt" data-id="key-red" data-name="Crimson Key" data-price="6.36" data-img="assets/keys/key-red.svg" data-kp-img="assets/previews/crimson.png" data-kp-title="Crimson" data-kp-desc="Choose 1 of the following upgraded items:<br>- Netherite Helmet (Protection V, Respiration III, Aqua Affinity, Thorns III, Unbreaking III, Mending)<br>- Netherite Chestplate (Protection IV, Thorns III, Unbreaking III, Mending)<br>- Netherite Leggings (Protection IV, Swift Sneak III, Thorns III, Unbreaking III, Mending)<br>- Netherite Boots (Protection IV, Feather Falling IV, Soul Speed III, Depth Strider III, Thorns III, Unbreaking III, Mending)<br>- Netherite Sword (Sharpness V, Sweeping Edge III, Fire Aspect II, Knockback II, Looting III, Unbreaking III, Mending)<br>- Netherite Pickaxe (Silk Touch, Efficiency V, Unbreaking III, Mending)<br>- Netherite Axe (Sharpness V, Silk Touch, Efficiency V, Unbreaking III, Mending)<br>- Crossbow (Multishot, Quick Charge III, Unbreaking III, Mending)<br>- Mace (Breach IV, Unbreaking III, Mending)">
+          <div class="card tilt" data-id="key-red" data-name="Crimson Key" data-name-key="products.crimson.name" data-price="6.36" data-img="assets/keys/key-red.svg" data-kp-img="assets/previews/crimson.png" data-kp-title="Crimson" data-kp-desc="Choose 1 of the following upgraded items:<br>- Netherite Helmet (Protection V, Respiration III, Aqua Affinity, Thorns III, Unbreaking III, Mending)<br>- Netherite Chestplate (Protection IV, Thorns III, Unbreaking III, Mending)<br>- Netherite Leggings (Protection IV, Swift Sneak III, Thorns III, Unbreaking III, Mending)<br>- Netherite Boots (Protection IV, Feather Falling IV, Soul Speed III, Depth Strider III, Thorns III, Unbreaking III, Mending)<br>- Netherite Sword (Sharpness V, Sweeping Edge III, Fire Aspect II, Knockback II, Looting III, Unbreaking III, Mending)<br>- Netherite Pickaxe (Silk Touch, Efficiency V, Unbreaking III, Mending)<br>- Netherite Axe (Sharpness V, Silk Touch, Efficiency V, Unbreaking III, Mending)<br>- Crossbow (Multishot, Quick Charge III, Unbreaking III, Mending)<br>- Mace (Breach IV, Unbreaking III, Mending)">
             <img src="assets/keys/key-red.svg" alt="Crimson Key" draggable="false"  data-kp-img="assets/previews/crimson.png" data-kp-title="Crimson" data-kp-desc="Choose 1 of the following upgraded items:<br>- Netherite Helmet (Protection V, Respiration III, Aqua Affinity, Thorns III, Unbreaking III, Mending)<br>- Netherite Chestplate (Protection IV, Thorns III, Unbreaking III, Mending)<br>- Netherite Leggings (Protection IV, Swift Sneak III, Thorns III, Unbreaking III, Mending)<br>- Netherite Boots (Protection IV, Feather Falling IV, Soul Speed III, Depth Strider III, Thorns III, Unbreaking III, Mending)<br>- Netherite Sword (Sharpness V, Sweeping Edge III, Fire Aspect II, Knockback II, Looting III, Unbreaking III, Mending)<br>- Netherite Pickaxe (Silk Touch, Efficiency V, Unbreaking III, Mending)<br>- Netherite Axe (Sharpness V, Silk Touch, Efficiency V, Unbreaking III, Mending)<br>- Crossbow (Multishot, Quick Charge III, Unbreaking III, Mending)<br>- Mace (Breach IV, Unbreaking III, Mending)" />
-            <h3>Crimson Key</h3>
+            <h3 data-i18n="products.crimson.name">Crimson Key</h3>
             <p class="price">$6.36</p>
             <div class="actions">
-              <label>Qty</label>
+              <label data-i18n="products.quantity">Qty</label>
               <select class="qty">
                 <option selected>1</option><option>3</option><option>5</option><option>10</option>
               </select>
-              <button class="btn add">Add</button>
+              <button class="btn add" data-i18n="products.add">Add</button>
             </div>
           </div>
 
-          <div class="card tilt" data-id="key-purple" data-name="Amethyst Key" data-price="3.65" data-img="assets/keys/key-purple.svg" data-kp-img="assets/previews/amethyst.png" data-kp-title="Amethyst" data-kp-desc="Choose 1 of the following Amethyst items:
+          <div class="card tilt" data-id="key-purple" data-name="Amethyst Key" data-name-key="products.amethyst.name" data-price="3.65" data-img="assets/keys/key-purple.svg" data-kp-img="assets/previews/amethyst.png" data-kp-title="Amethyst" data-kp-desc="Choose 1 of the following Amethyst items:
 - Amethyst Tree Chopper → Instantly breaks trees. (Disappears after 3 days)
 - Amethyst Sell Axe → Instantly sells all items in a chest. (Disappears after 3 days)
 - Amethyst Drill → Mines 9 blocks per break. (Disappears after 3 days)
@@ -203,14 +203,14 @@
 - Shard Booster → 4× Shard production for 24 hours. (Disappears after 3 days)
 - Amethyst Bucket → Drains 27 water blocks at once. (Disappears after 3 days)">
             <img src="assets/keys/key-purple.svg" alt="Amethyst Key" draggable="false"  data-kp-img="assets/previews/amethyst.png" data-kp-title="Amethyst" data-kp-desc="Choose 1 of the following Amethyst items:<br>- Amethyst Tree Chopper → Instantly breaks trees. (Disappears after 3 days)<br>- Amethyst Sell Axe → Instantly sells all items in a chest. (Disappears after 3 days)<br>- Amethyst Drill → Mines 9 blocks per break. (Disappears after 3 days)<br>- Amethyst Shovel → Digs 9 blocks per break. (Disappears after 3 days)<br>- Shard Booster → 4× Shard production for 24 hours. (Disappears after 3 days)<br>- Amethyst Bucket → Drains 27 water blocks at once. (Disappears after 3 days)" />
-            <h3>Amethyst Key</h3>
+            <h3 data-i18n="products.amethyst.name">Amethyst Key</h3>
             <p class="price">$3.65</p>
             <div class="actions">
-              <label>Qty</label>
+              <label data-i18n="products.quantity">Qty</label>
               <select class="qty">
                 <option>1</option><option selected>3</option><option>5</option><option>10</option>
               </select>
-              <button class="btn add">Add</button>
+              <button class="btn add" data-i18n="products.add">Add</button>
             </div>
           </div>
         </div>
@@ -220,24 +220,24 @@
     <section class="support-section">
       <div class="container support reveal" data-animate="fade-up">
         <div class="section-heading">
-          <p class="eyebrow">Support &amp; Contact</p>
-          <h2>Need a Hand? We’re Here for You</h2>
-          <p>If you have questions or run into an issue, reach out and our staff will guide you step by step.</p>
+          <p class="eyebrow" data-i18n="support.eyebrow">Support &amp; Contact</p>
+          <h2 data-i18n="support.heading">Need a Hand? We’re Here for You</h2>
+          <p data-i18n="support.description">If you have questions or run into an issue, reach out and our staff will guide you step by step.</p>
         </div>
         <div class="support-content">
-          <a href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener" class="btn btn-glow">Open a Discord Ticket</a>
+          <a href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener" class="btn btn-glow" data-i18n="support.openTicket">Open a Discord Ticket</a>
           <div class="support-details">
             <div>
-              <span class="detail-label">Discord</span>
-              <span class="detail-value">Join the server and open <strong>🔧│support</strong>.</span>
+              <span class="detail-label" data-i18n="support.discordLabel">Discord</span>
+              <span class="detail-value" data-i18n-html="support.discordValue">Join the server and open <strong>🔧│support</strong>.</span>
             </div>
             <div>
-              <span class="detail-label">Delivery Channel</span>
-              <span class="detail-value">Stay in <strong>🔑│key-delivery-wait</strong> for manual delivery.</span>
+              <span class="detail-label" data-i18n="support.deliveryLabel">Delivery Channel</span>
+              <span class="detail-value" data-i18n-html="support.deliveryValue">Stay in <strong>🔑│key-delivery-wait</strong> for manual delivery.</span>
             </div>
             <div>
-              <span class="detail-label">Telegram</span>
-              <span class="detail-value">Message <strong>m7mdd_x</strong> for urgent assistance.</span>
+              <span class="detail-label" data-i18n="support.telegramLabel">Telegram</span>
+              <span class="detail-value" data-i18n-html="support.telegramValue">Message <strong>m7mdd_x</strong> for urgent assistance.</span>
             </div>
           </div>
         </div>
@@ -248,60 +248,60 @@
   <!-- Cart Drawer -->
   <aside id="cart" class="cart">
     <div class="cart-head">
-      <h3>Your Cart</h3>
-      <button id="close-cart" class="icon-btn" aria-label="Close">✕</button>
+      <h3 data-i18n="cart.title">Your Cart</h3>
+      <button id="close-cart" class="icon-btn" aria-label="Close" data-i18n-aria-label="cart.closeAria">✕</button>
     </div>
     <ul id="cart-items" class="cart-items"></ul>
     <div class="cart-foot">
-      <div class="total">Total: <span id="cart-total">$0.00</span></div>
+      <div class="total" data-i18n-html="cart.total">Total: <span id="cart-total">$0.00</span></div>
       <div class="cart-buttons">
-        <button id="clear-cart" class="btn btn-ghost">Clear</button>
-        <button id="checkout" class="btn">Checkout</button>
+        <button id="clear-cart" class="btn btn-ghost" data-i18n="cart.clear">Clear</button>
+        <button id="checkout" class="btn" data-i18n="cart.checkout">Checkout</button>
       </div>
-      <small class="hint">Enter your <b>Minecraft username</b> during checkout. Delivery is automatic in-game.</small>
+      <small class="hint" data-i18n-html="cart.hint">Enter your <b>Minecraft username</b> during checkout. Delivery is automatic in-game.</small>
     </div>
   </aside>
 
   <!-- Checkout modal -->
   <div id="checkout-modal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="modal-panel">
-      <button type="button" class="modal-close" id="close-modal" aria-label="Close">✕</button>
-      <h3>Complete Your Order</h3>
-      <p class="modal-lead">
+      <button type="button" class="modal-close" id="close-modal" aria-label="Close" data-i18n-aria-label="checkout.closeAria">✕</button>
+      <h3 data-i18n="checkout.title">Complete Your Order</h3>
+      <p class="modal-lead" data-i18n="checkout.lead">
         Before paying, please make sure you have opened a complaint/support ticket if you faced any issues.
         We also need your in-game details so staff can deliver your keys quickly after payment.
       </p>
       <form id="checkout-form" class="modal-form">
         <label class="field">
-          <span>Minecraft Username</span>
-          <input type="text" id="minecraft-name" name="minecraft" autocomplete="username" placeholder="Ex: Notch" required />
+          <span data-i18n="checkout.minecraftLabel">Minecraft Username</span>
+          <input type="text" id="minecraft-name" name="minecraft" autocomplete="username" placeholder="Ex: Notch" required data-i18n-placeholder="checkout.minecraftPlaceholder" />
         </label>
         <label class="field">
-          <span>Discord Username</span>
-          <input type="text" id="discord-name" name="discord" autocomplete="off" placeholder="Ex: Player#1234" required />
+          <span data-i18n="checkout.discordLabel">Discord Username</span>
+          <input type="text" id="discord-name" name="discord" autocomplete="off" placeholder="Ex: Player#1234" required data-i18n-placeholder="checkout.discordPlaceholder" />
         </label>
         <label class="field">
-          <span>Complaint / Ticket Status</span>
+          <span data-i18n="checkout.ticketLabel">Complaint / Ticket Status</span>
           <select id="complaint-status" name="complaint" required>
-            <option value="" disabled selected>Select an option</option>
-            <option value="no-issue">No complaints, I'm ready to pay.</option>
-            <option value="submitted">I already opened a ticket about an issue.</option>
-            <option value="need-help">I still need help before paying.</option>
+            <option value="" disabled selected data-i18n="checkout.optionPlaceholder">Select an option</option>
+            <option value="no-issue" data-i18n="checkout.optionReady">No complaints, I'm ready to pay.</option>
+            <option value="submitted" data-i18n="checkout.optionSubmitted">I already opened a ticket about an issue.</option>
+            <option value="need-help" data-i18n="checkout.optionNeedHelp">I still need help before paying.</option>
           </select>
         </label>
         <p id="checkout-message" class="modal-message" role="alert" aria-live="polite"></p>
-        <button type="submit" class="btn btn-wide">Review Order &amp; Pay</button>
+        <button type="submit" class="btn btn-wide" data-i18n="checkout.review">Review Order &amp; Pay</button>
       </form>
       <section id="checkout-summary" class="modal-summary" hidden>
-        <h4>Order Summary</h4>
+        <h4 data-i18n="checkout.summaryTitle">Order Summary</h4>
         <ul id="summary-items"></ul>
-        <p class="summary-total">Total: <span id="summary-total"></span></p>
-        <p class="summary-note">
+        <p class="summary-total" data-i18n-html="checkout.summaryTotal">Total: <span id="summary-total"></span></p>
+        <p class="summary-note" data-i18n="checkout.summaryNote">
           Copy the order details and share them in your Discord ticket. Our team will process the payment with you and deliver the keys manually after confirming your Minecraft and Discord names.
         </p>
         <div class="summary-actions">
-          <button type="button" class="btn btn-ghost" id="copy-order">Copy Order Details</button>
-          <a class="btn" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener">Open Discord Ticket</a>
+          <button type="button" class="btn btn-ghost" id="copy-order" data-i18n="checkout.copy">Copy Order Details</button>
+          <a class="btn" href="https://discord.gg/nQRNkPc8y" target="_blank" rel="noopener" data-i18n="checkout.openTicket">Open Discord Ticket</a>
         </div>
       </section>
     </div>
@@ -325,6 +325,7 @@
     })();
   </script>
   <script src="assets/panel.js"></script>
+  <script src="lang-config.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/lang-config.js
+++ b/lang-config.js
@@ -1,0 +1,14 @@
+window.languageConfig = window.languageConfig || {
+  defaultLanguage: 'en',
+  translations: {
+    ar: {
+      // Provide manual Arabic translations here, e.g.:
+      // 'nav.joinDiscord': 'انضم إلى ديسكورد',
+    }
+  },
+  googleTranslate: {
+    apiKey: '',
+    endpoint: 'https://translation.googleapis.com/language/translate/v2',
+    source: 'en'
+  }
+};

--- a/script.js
+++ b/script.js
@@ -7,7 +7,337 @@ const $$ = (sel, ctx=document) => [...ctx.querySelectorAll(sel)];
 
 const fmt = n => '$' + (Math.round(n * 100) / 100).toFixed(2);
 
+const LANGUAGE_KEY = 'arabsmp_language';
+const AUTO_TRANSLATION_KEY = 'arabsmp_i18n_cache_v1';
+
+class I18nManager {
+  constructor(config = {}) {
+    this.config = config;
+    this.defaultLanguage = config.defaultLanguage || 'en';
+    this.language = this.defaultLanguage;
+    this.manualTranslations = config.translations || {};
+    this.googleConfig = config.googleTranslate || {};
+    this.baseTexts = {};
+    this.entries = new Map();
+    this.extraKeys = new Set();
+    this.listeners = new Set();
+    this.cache = this.loadCache();
+    this.registerDomEntries();
+    const storedLang = this.getStoredLanguage();
+    if (storedLang) {
+      this.language = storedLang;
+    }
+  }
+
+  onChange(fn) {
+    if (typeof fn === 'function') {
+      this.listeners.add(fn);
+    }
+  }
+
+  registerDomEntries() {
+    this.registerElements('[data-i18n]', 'i18n', el => el.textContent, (el, val) => { el.textContent = val; });
+    this.registerElements('[data-i18n-html]', 'i18nHtml', el => el.innerHTML, (el, val) => { el.innerHTML = val; });
+    this.registerElements('[data-i18n-placeholder]', 'i18nPlaceholder', el => el.getAttribute('placeholder'), (el, val) => { el.setAttribute('placeholder', val); });
+    this.registerElements('[data-i18n-aria-label]', 'i18nAriaLabel', el => el.getAttribute('aria-label'), (el, val) => { el.setAttribute('aria-label', val); });
+  }
+
+  registerElements(selector, dataKey, getter, setter) {
+    $$(selector).forEach(el => {
+      const key = el.dataset[dataKey];
+      if (!key) return;
+      this.registerEntry(key, getter(el));
+      const entry = { el, setter, key };
+      if (!this.entries.has(key)) {
+        this.entries.set(key, []);
+      }
+      this.entries.get(key).push(entry);
+    });
+  }
+
+  registerEntry(key, value) {
+    if (key && typeof value === 'string' && !(key in this.baseTexts)) {
+      this.baseTexts[key] = value;
+    }
+  }
+
+  registerString(key, value, { preload = false } = {}) {
+    this.registerEntry(key, value);
+    if (preload) {
+      this.extraKeys.add(key);
+    }
+  }
+
+  getStoredLanguage() {
+    try {
+      return localStorage.getItem(LANGUAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  storeLanguage(lang) {
+    try {
+      localStorage.setItem(LANGUAGE_KEY, lang);
+    } catch {
+      /* no-op */
+    }
+  }
+
+  loadCache() {
+    try {
+      return JSON.parse(localStorage.getItem(AUTO_TRANSLATION_KEY)) || {};
+    } catch {
+      return {};
+    }
+  }
+
+  saveCache() {
+    try {
+      localStorage.setItem(AUTO_TRANSLATION_KEY, JSON.stringify(this.cache));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  getManual(lang, key) {
+    return (this.manualTranslations[lang] && this.manualTranslations[lang][key]) ?? null;
+  }
+
+  getCached(lang, key) {
+    return this.cache[lang] && this.cache[lang][key];
+  }
+
+  setCache(lang, key, value) {
+    if (!this.cache[lang]) {
+      this.cache[lang] = {};
+    }
+    this.cache[lang][key] = value;
+  }
+
+  async initialize() {
+    await this.setLanguage(this.language);
+  }
+
+  async setLanguage(lang) {
+    const target = lang || this.defaultLanguage;
+    await this.ensureTranslations(target);
+    this.applyLanguage(target);
+    this.language = target;
+    this.storeLanguage(target);
+    this.listeners.forEach(fn => fn(target));
+  }
+
+  async ensureTranslations(lang) {
+    if (lang === this.defaultLanguage) {
+      return;
+    }
+    const manual = this.manualTranslations[lang] || {};
+    const needed = new Set();
+    this.entries.forEach((_, key) => {
+      if (manual[key] != null) return;
+      if (this.getCached(lang, key)) return;
+      needed.add(key);
+    });
+    this.extraKeys.forEach(key => {
+      if (manual[key] != null) return;
+      if (this.getCached(lang, key)) return;
+      needed.add(key);
+    });
+    if (!needed.size) return;
+    try {
+      await this.fetchTranslations([...needed], lang);
+      this.saveCache();
+    } catch (err) {
+      console.warn('Translation request failed', err);
+    }
+  }
+
+  applyLanguage(lang) {
+    const manual = this.manualTranslations[lang] || {};
+    this.entries.forEach((list, key) => {
+      let value = this.baseTexts[key] ?? '';
+      if (lang !== this.defaultLanguage) {
+        if (manual[key] != null) {
+          value = manual[key];
+        } else {
+          value = this.getCached(lang, key) ?? value;
+        }
+      }
+      list.forEach(entry => entry.setter(entry.el, value));
+    });
+    const root = document.documentElement;
+    root.lang = lang;
+    if (lang === 'ar') {
+      root.dir = 'rtl';
+      document.body.classList.add('lang-ar');
+    } else {
+      root.dir = 'ltr';
+      document.body.classList.remove('lang-ar');
+    }
+  }
+
+  async fetchTranslations(keys, lang) {
+    const texts = keys.map(key => this.baseTexts[key] ?? '');
+    if (!texts.length) return;
+    const source = this.googleConfig.source || this.defaultLanguage || 'en';
+    if (this.googleConfig.apiKey) {
+      const endpoint = this.googleConfig.endpoint || 'https://translation.googleapis.com/language/translate/v2';
+      const response = await fetch(`${endpoint}?key=${this.googleConfig.apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ q: texts, target: lang, source, format: 'html' })
+      });
+      if (!response.ok) throw new Error('Google Translate API error');
+      const data = await response.json();
+      const translations = (data && data.data && data.data.translations) || [];
+      translations.forEach((item, idx) => {
+        const translated = item.translatedText || '';
+        this.setCache(lang, keys[idx], translated);
+      });
+      return;
+    }
+    for (let i = 0; i < keys.length; i += 1) {
+      const text = texts[i];
+      const key = keys[i];
+      const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${encodeURIComponent(source)}&tl=${encodeURIComponent(lang)}&dt=t&q=${encodeURIComponent(text)}`;
+      try {
+        const response = await fetch(url);
+        if (!response.ok) continue;
+        const data = await response.json();
+        const translated = Array.isArray(data) && Array.isArray(data[0])
+          ? data[0].map(part => part[0]).join('')
+          : '';
+        if (translated) {
+          this.setCache(lang, key, translated);
+        }
+      } catch (err) {
+        console.warn('Fallback translation failed', err);
+      }
+    }
+  }
+
+  async get(key, fallback = '') {
+    if (!(key in this.baseTexts) && fallback) {
+      this.registerEntry(key, fallback);
+    }
+    if (this.language === this.defaultLanguage) {
+      return this.baseTexts[key] ?? fallback;
+    }
+    const manual = this.getManual(this.language, key);
+    if (manual != null) return manual;
+    const cached = this.getCached(this.language, key);
+    if (cached != null) return cached;
+    try {
+      await this.fetchTranslations([key], this.language);
+      this.saveCache();
+    } catch (err) {
+      console.warn('Translation fetch failed for key', key, err);
+    }
+    return this.getCached(this.language, key) ?? (this.baseTexts[key] ?? fallback);
+  }
+
+  instant(key, fallback = '') {
+    if (this.language === this.defaultLanguage) {
+      return this.baseTexts[key] ?? fallback;
+    }
+    const manual = this.getManual(this.language, key);
+    if (manual != null) return manual;
+    return this.getCached(this.language, key) ?? (this.baseTexts[key] ?? fallback);
+  }
+}
+
+const i18n = new I18nManager(window.languageConfig || {});
+
+i18n.registerString('nav.themeLight', 'Light', { preload: true });
+i18n.registerString('nav.themeDark', 'Dark', { preload: true });
+i18n.registerString('nav.themeAriaLight', 'Switch to light mode', { preload: true });
+i18n.registerString('nav.themeAriaDark', 'Switch to dark mode', { preload: true });
+i18n.registerString('nav.languageSwitchAr', 'Switch to Arabic', { preload: true });
+i18n.registerString('nav.languageSwitchEn', 'Switch to English', { preload: true });
+i18n.registerString('messages.emptyCartAlert', 'Your cart is empty. Add a key before checking out.', { preload: true });
+i18n.registerString('messages.emptyCartInline', 'Your cart is empty. Add items before checking out.', { preload: true });
+i18n.registerString('messages.fillAllFields', 'Please fill in all fields to continue.', { preload: true });
+i18n.registerString('messages.needHelp', 'Open a support ticket in Discord so staff can help you before paying.', { preload: true });
+i18n.registerString('messages.generateDetails', 'Submit the form above to generate order details.', { preload: true });
+i18n.registerString('messages.copied', 'Copied!', { preload: true });
+i18n.registerString('cart.remove', 'Remove', { preload: true });
+i18n.registerString('checkout.summaryMinecraft', 'Minecraft', { preload: true });
+i18n.registerString('checkout.summaryDiscord', 'Discord', { preload: true });
+i18n.registerString('checkout.summaryTicket', 'Ticket status', { preload: true });
+i18n.registerString('checkout.summaryItemsHeading', 'Items', { preload: true });
+i18n.registerString('checkout.summaryItemsLabel', 'Items:', { preload: true });
+i18n.registerString('checkout.totalLabel', 'Total:', { preload: true });
+
 const themeToggle = $('#theme-toggle');
+const menuToggle = $('#menu-toggle');
+const primaryNav = $('#primary-nav');
+const languageToggle = $('#language-toggle');
+const languageToggleText = languageToggle ? $('.language-toggle-text', languageToggle) : null;
+
+const PRODUCT_NAME_KEYS = {
+  'key-green': 'products.common.name',
+  'key-blue': 'products.prime.name',
+  'key-gold': 'products.gold.name',
+  'key-red': 'products.crimson.name',
+  'key-purple': 'products.amethyst.name'
+};
+
+function updateLanguageToggleUI(lang){
+  if(!languageToggle) return;
+  const nextLang = lang === 'ar' ? 'en' : 'ar';
+  if(languageToggleText){
+    languageToggleText.textContent = nextLang.toUpperCase();
+  }
+  const labelKey = nextLang === 'ar' ? 'nav.languageSwitchAr' : 'nav.languageSwitchEn';
+  const fallback = nextLang === 'ar' ? 'Switch to Arabic' : 'Switch to English';
+  languageToggle.setAttribute('aria-label', i18n.instant(labelKey, fallback));
+  languageToggle.setAttribute('aria-pressed', lang === 'ar' ? 'true' : 'false');
+}
+
+if(menuToggle && primaryNav){
+  document.body.classList.add('menu-enhanced');
+  const closeMenu = () => {
+    primaryNav.classList.remove('is-open');
+    menuToggle.classList.remove('is-active');
+    menuToggle.setAttribute('aria-expanded', 'false');
+  };
+
+  menuToggle.addEventListener('click', () => {
+    const isOpen = !primaryNav.classList.contains('is-open');
+    primaryNav.classList.toggle('is-open', isOpen);
+    menuToggle.classList.toggle('is-active', isOpen);
+    menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  });
+
+  $$('#primary-nav a, #primary-nav button').forEach(el => {
+    el.addEventListener('click', () => closeMenu());
+  });
+
+  const mq = window.matchMedia('(min-width: 768px)');
+  mq.addEventListener('change', e => { if(e.matches) closeMenu(); });
+
+  closeMenu();
+}
+
+if(languageToggle){
+  languageToggle.addEventListener('click', async () => {
+    const nextLang = i18n.language === 'ar' ? 'en' : 'ar';
+    languageToggle.disabled = true;
+    try {
+      await i18n.setLanguage(nextLang);
+    } finally {
+      languageToggle.disabled = false;
+    }
+  });
+}
+
+i18n.onChange(lang => {
+  updateLanguageToggleUI(lang);
+  renderCart();
+  const currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+  applyTheme(currentTheme, { persist:false, animate:false });
+});
 
 function applyTheme(theme, { persist = true, animate = true } = {}){
   const next = theme === 'light' ? 'light' : 'dark';
@@ -15,16 +345,15 @@ function applyTheme(theme, { persist = true, animate = true } = {}){
   if(themeToggle){
     const icon = $('.theme-icon', themeToggle);
     const text = $('.theme-text', themeToggle);
-    if(next === 'dark'){
-      themeToggle.setAttribute('aria-label', 'Switch to light mode');
-      themeToggle.setAttribute('aria-pressed', 'true');
-      if(icon) icon.textContent = '🌙';
-      if(text) text.textContent = 'Dark';
-    } else {
-      themeToggle.setAttribute('aria-label', 'Switch to dark mode');
-      themeToggle.setAttribute('aria-pressed', 'false');
-      if(icon) icon.textContent = '☀️';
-      if(text) text.textContent = 'Light';
+    const labelKey = next === 'dark' ? 'nav.themeAriaLight' : 'nav.themeAriaDark';
+    const labelFallback = next === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+    themeToggle.setAttribute('aria-label', i18n.instant(labelKey, labelFallback));
+    themeToggle.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
+    if(icon) icon.textContent = next === 'dark' ? '🌙' : '☀️';
+    if(text){
+      const textKey = next === 'dark' ? 'nav.themeDark' : 'nav.themeLight';
+      const textFallback = next === 'dark' ? 'Dark' : 'Light';
+      text.textContent = i18n.instant(textKey, textFallback);
     }
     if(animate){
       themeToggle.classList.remove('theme-toggle-spin');
@@ -80,8 +409,16 @@ function refreshBadge(items = getCart()){
 function addToCart(item){
   const items = getCart();
   const found = items.find(i => i.id === item.id);
-  if(found){ found.qty += item.qty; }
-  else { items.push(item); }
+  if(found){
+    found.qty += item.qty;
+    if(item.name) found.name = item.name;
+    if(item.baseName) found.baseName = item.baseName;
+    if(item.nameKey) found.nameKey = item.nameKey;
+    if(item.img) found.img = item.img;
+    if(item.price) found.price = item.price;
+  } else {
+    items.push({ ...item });
+  }
   saveCart(items);
   renderCart();
   animateCart();
@@ -109,21 +446,36 @@ function renderCart(){
   const items = getCart();
   list.innerHTML = '';
   let total = 0;
+  let mutated = false;
   items.forEach(i=>{
     total += i.price * i.qty;
+    const inferredKey = i.nameKey || PRODUCT_NAME_KEYS[i.id];
+    if(inferredKey && !i.nameKey){
+      i.nameKey = inferredKey;
+      mutated = true;
+    }
+    const baseFromConfig = i.nameKey ? (i.baseName || i18n.baseTexts[i.nameKey]) : null;
+    if(!i.baseName){
+      i.baseName = baseFromConfig || i.name || '';
+      if(i.baseName) mutated = true;
+    }
     const li = document.createElement('li');
     li.className = 'cart-item';
+    const nameKey = i.nameKey;
+    const baseName = i.baseName || '';
+    const displayName = nameKey ? i18n.instant(nameKey, baseName) : baseName;
+    const removeLabel = i18n.instant('cart.remove', 'Remove');
     li.innerHTML = `
-      <img src="${i.img}" alt="${i.name}" />
+      <img src="${i.img}" alt="${htmlEscape(displayName)}" />
       <div>
-        <div class="name">${i.name}</div>
+        <div class="name">${htmlEscape(displayName)}</div>
         <div class="meta">${fmt(i.price)} ×
           <input type="number" min="1" value="${i.qty}" class="qty-input" />
         </div>
       </div>
       <div style="display:grid;gap:6px;justify-items:end">
         <div><b>${fmt(i.price * i.qty)}</b></div>
-        <button class="remove">Remove</button>
+        <button class="remove">${htmlEscape(removeLabel)}</button>
       </div>
     `;
     const qtyInput = $('input', li);
@@ -135,12 +487,16 @@ function renderCart(){
     list.appendChild(li);
   });
   $('#cart-total').textContent = fmt(total);
+  if(mutated){
+    saveCart(items);
+  }
 }
 
 function bindProducts(){
   $$('.card').forEach(card => {
     const id = card.dataset.id;
     const name = card.dataset.name;
+    const nameKey = card.dataset.nameKey || PRODUCT_NAME_KEYS[id];
     const price = parseFloat(card.dataset.price);
     const img = card.dataset.img;
     const qtySel = $('.qty', card);
@@ -149,7 +505,9 @@ function bindProducts(){
       void card.offsetWidth;
       card.classList.add('card-added');
       setTimeout(() => card.classList.remove('card-added'), 500);
-      addToCart({ id, name, price, img, qty: parseInt(qtySel.value, 10) });
+      const titleEl = $('h3', card);
+      const displayName = titleEl ? titleEl.textContent.trim() : name;
+      addToCart({ id, name: displayName, baseName: name, nameKey, price, img, qty: parseInt(qtySel.value, 10) });
       openCart();
     });
   });
@@ -195,10 +553,10 @@ const htmlEscape = str => str.replace(/[&<>"']/g, ch => ({
   "'": '&#39;'
 }[ch] || ch));
 
-function openCheckoutModal(){
+async function openCheckoutModal(){
   const items = getCart();
   if(!items.length){
-    alert('Your cart is empty. Add a key before checking out.');
+    alert(await i18n.get('messages.emptyCartAlert', 'Your cart is empty. Add a key before checking out.'));
     return;
   }
   closeCart();
@@ -224,28 +582,22 @@ checkoutModal.addEventListener('click', e => {
   if(e.target === checkoutModal) closeCheckoutModal();
 });
 
-const statusLabels = {
-  'no-issue': 'No complaints, ready to pay',
-  'submitted': 'I already opened a ticket',
-  'need-help': 'I still need help before paying'
-};
-
-checkoutForm.addEventListener('submit', e => {
+checkoutForm.addEventListener('submit', async e => {
   e.preventDefault();
   const items = getCart();
   if(!items.length){
-    checkoutMessage.textContent = 'Your cart is empty. Add items before checking out.';
+    checkoutMessage.textContent = await i18n.get('messages.emptyCartInline', 'Your cart is empty. Add items before checking out.');
     return;
   }
   const minecraft = minecraftInput.value.trim();
   const discord = discordInput.value.trim();
   const complaint = complaintSelect.value;
   if(!minecraft || !discord || !complaint){
-    checkoutMessage.textContent = 'Please fill in all fields to continue.';
+    checkoutMessage.textContent = await i18n.get('messages.fillAllFields', 'Please fill in all fields to continue.');
     return;
   }
   if(complaint === 'need-help'){
-    checkoutMessage.textContent = 'Open a support ticket in Discord so staff can help you before paying.';
+    checkoutMessage.textContent = await i18n.get('messages.needHelp', 'Open a support ticket in Discord so staff can help you before paying.');
     summarySection.hidden = true;
     return;
   }
@@ -256,16 +608,22 @@ checkoutForm.addEventListener('submit', e => {
   const details = [];
   const addSummaryItem = (label, value) => {
     const li = document.createElement('li');
-    li.innerHTML = `<strong>${label}:</strong> ${htmlEscape(value)}`;
+    li.innerHTML = `<strong>${htmlEscape(label)}:</strong> ${htmlEscape(value)}`;
     summaryItems.appendChild(li);
   };
 
-  addSummaryItem('Minecraft', minecraft);
-  addSummaryItem('Discord', discord);
-  addSummaryItem('Ticket status', statusLabels[complaint] || complaint);
+  const minecraftLabel = await i18n.get('checkout.summaryMinecraft', 'Minecraft');
+  const discordLabel = await i18n.get('checkout.summaryDiscord', 'Discord');
+  const ticketLabel = await i18n.get('checkout.summaryTicket', 'Ticket status');
+  addSummaryItem(minecraftLabel, minecraft);
+  addSummaryItem(discordLabel, discord);
+  const selectedOption = complaintSelect.options[complaintSelect.selectedIndex];
+  const ticketValue = selectedOption ? selectedOption.textContent : complaint;
+  addSummaryItem(ticketLabel, ticketValue);
 
   const itemsHeader = document.createElement('li');
-  itemsHeader.innerHTML = '<strong>Items</strong>';
+  const itemsHeading = await i18n.get('checkout.summaryItemsHeading', 'Items');
+  itemsHeader.innerHTML = `<strong>${htmlEscape(itemsHeading)}</strong>`;
   summaryItems.appendChild(itemsHeader);
 
   let total = 0;
@@ -273,35 +631,44 @@ checkoutForm.addEventListener('submit', e => {
     const lineTotal = item.price * item.qty;
     total += lineTotal;
     const li = document.createElement('li');
-    li.innerHTML = `${htmlEscape(item.name)} × ${item.qty} — <strong>${fmt(lineTotal)}</strong>`;
+    const productNameKey = item.nameKey || PRODUCT_NAME_KEYS[item.id];
+    const productNameFallback = item.baseName || item.name || '';
+    const productName = productNameKey ? i18n.instant(productNameKey, productNameFallback) : productNameFallback;
+    li.innerHTML = `${htmlEscape(productName)} × ${item.qty} — <strong>${fmt(lineTotal)}</strong>`;
     summaryItems.appendChild(li);
-    details.push(`${item.name} x${item.qty} - ${fmt(lineTotal)}`);
+    details.push(`${productName} x${item.qty} - ${fmt(lineTotal)}`);
   });
 
   summaryTotal.textContent = fmt(total);
   summarySection.hidden = false;
 
+  const summaryTicketValue = ticketValue;
+  const itemsLabel = await i18n.get('checkout.summaryItemsLabel', 'Items:');
+  const totalLabel = await i18n.get('checkout.totalLabel', 'Total:');
   lastOrderDetails = [
-    `Minecraft: ${minecraft}`,
-    `Discord: ${discord}`,
-    `Ticket status: ${statusLabels[complaint] || complaint}`,
-    'Items:',
+    `${minecraftLabel}: ${minecraft}`,
+    `${discordLabel}: ${discord}`,
+    `${ticketLabel}: ${summaryTicketValue}`,
+    itemsLabel,
     ...details,
-    `Total: ${fmt(total)}`
+    `${totalLabel} ${fmt(total)}`
   ].join('\n');
 });
 
 if(copyOrderBtn){
-  copyOrderBtn.addEventListener('click', () => {
+  copyOrderBtn.addEventListener('click', async () => {
     if(!lastOrderDetails){
-      checkoutMessage.textContent = 'Submit the form above to generate order details.';
+      checkoutMessage.textContent = await i18n.get('messages.generateDetails', 'Submit the form above to generate order details.');
       return;
     }
-    navigator.clipboard.writeText(lastOrderDetails).then(() => {
-      const original = copyOrderBtn.textContent;
-      copyOrderBtn.textContent = 'Copied!';
-      setTimeout(() => { copyOrderBtn.textContent = original; }, 1800);
-    });
+    try {
+      await navigator.clipboard.writeText(lastOrderDetails);
+      const copiedText = await i18n.get('messages.copied', 'Copied!');
+      copyOrderBtn.textContent = copiedText;
+      setTimeout(() => { copyOrderBtn.textContent = i18n.instant('checkout.copy', 'Copy Order Details'); }, 1800);
+    } catch (err) {
+      console.warn('Copy failed', err);
+    }
   });
 }
 
@@ -315,12 +682,23 @@ window.addEventListener('keydown', e => {
 });
 
 // IP copy
-function copyIP(){
+async function copyIP(){
   const ip = $('#server-ip').textContent.trim();
-  navigator.clipboard.writeText(ip).then(()=>{
-    const btns = ['#copy-ip','#copy-ip-hero'];
-    btns.forEach(sel=>{ const b=$(sel); if(b){ b.textContent='Copied!'; setTimeout(()=>b.textContent= sel.includes('hero')?'Copy':'Copy IP', 1400);} });
-  });
+  try {
+    await navigator.clipboard.writeText(ip);
+    const copiedLabel = await i18n.get('messages.copied', 'Copied!');
+    ['#copy-ip', '#copy-ip-hero'].forEach(sel => {
+      const btn = $(sel);
+      if(!btn) return;
+      btn.textContent = copiedLabel;
+      setTimeout(() => {
+        const resetLabel = sel.includes('hero') ? i18n.instant('hero.copy', 'Copy') : i18n.instant('nav.copyIp', 'Copy IP');
+        btn.textContent = resetLabel;
+      }, 1400);
+    });
+  } catch (err) {
+    console.warn('Copy IP failed', err);
+  }
 }
 $('#copy-ip').addEventListener('click', copyIP);
 $('#copy-ip-hero').addEventListener('click', copyIP);
@@ -363,9 +741,15 @@ function initRevealAnimations(){
 }
 
 // Init
-bindProducts();
-renderCart();
-refreshBadge();
-initRevealAnimations();
-initTheme();
+async function initApp(){
+  await i18n.initialize();
+  updateLanguageToggleUI(i18n.language);
+  bindProducts();
+  refreshBadge();
+  renderCart();
+  initRevealAnimations();
+  initTheme();
+}
+
+initApp();
 

--- a/styles.css
+++ b/styles.css
@@ -132,6 +132,48 @@ body {
   overflow-x:hidden;
 }
 
+body.lang-ar {
+  font-family:'Cairo', Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+body.lang-ar .nav {
+  direction:ltr;
+}
+
+body.lang-ar .nav > * {
+  direction:rtl;
+}
+
+body.lang-ar .language-toggle {
+  direction:ltr;
+  letter-spacing:0;
+}
+
+body.lang-ar .support {
+  text-align:right;
+}
+
+body.lang-ar .hero-content,
+body.lang-ar .feature-card,
+body.lang-ar .section-heading,
+body.lang-ar .support-details,
+body.lang-ar .hero-note,
+body.lang-ar .cart,
+body.lang-ar .cart-foot,
+body.lang-ar .modal-panel,
+body.lang-ar .modal-summary,
+body.lang-ar .modal-form {
+  text-align:right;
+}
+
+body.lang-ar .hero-steps li {
+  flex-direction:row-reverse;
+}
+
+body.lang-ar .cart-item {
+  direction:rtl;
+}
+
 body::before,
 body::after {
   content:"";
@@ -161,6 +203,18 @@ body::after {
 img { max-width:100%; height:auto; display:block; user-select:none; }
 
 a { color:inherit; text-decoration:none; }
+
+.sr-only {
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
 
 .container { width:min(1120px, 92%); margin-inline:auto; }
 
@@ -219,6 +273,59 @@ section { position:relative; }
 .header h1 { margin:0; font-size:20px; letter-spacing:.4px; font-weight:800; }
 
 .nav { display:flex; align-items:center; gap:12px; flex-wrap:wrap; justify-content:flex-end; }
+
+.menu-toggle {
+  display:none;
+  align-items:center;
+  justify-content:center;
+  width:42px;
+  height:42px;
+  border-radius:12px;
+  border:1px solid var(--surface-border);
+  background:var(--surface-glass);
+  color:var(--text);
+  cursor:pointer;
+  transition:background .25s ease, border-color .25s ease, transform .25s ease;
+}
+
+.menu-toggle:hover { background:var(--surface-glass-hover); }
+
+.menu-toggle:focus-visible {
+  outline:2px solid var(--outline-border);
+  outline-offset:3px;
+}
+
+.menu-icon,
+.menu-icon::before,
+.menu-icon::after {
+  display:block;
+  width:18px;
+  height:2px;
+  border-radius:999px;
+  background:currentColor;
+  transition:transform .3s ease, opacity .3s ease;
+  transform-origin:center;
+}
+
+.menu-icon { position:relative; }
+
+.menu-icon::before,
+.menu-icon::after {
+  content:"";
+  position:absolute;
+  left:0;
+}
+
+.menu-icon::before { top:-6px; }
+
+.menu-icon::after { top:6px; }
+
+.menu-toggle.is-active .menu-icon { background:transparent; }
+
+.menu-toggle.is-active .menu-icon::before { transform:translateY(6px) rotate(45deg); }
+
+.menu-toggle.is-active .menu-icon::after { transform:translateY(-6px) rotate(-45deg); }
+
 
 /* Buttons --------------------------------------------------------------- */
 .btn {
@@ -308,6 +415,18 @@ section { position:relative; }
 
 .theme-toggle-spin .theme-icon {
   transform:rotate(180deg) scale(0.9);
+}
+
+.language-toggle {
+  min-width:48px;
+  font-weight:700;
+  letter-spacing:0.8px;
+}
+
+.language-toggle-text {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
 }
 
 .btn-glow {
@@ -994,10 +1113,46 @@ section { position:relative; }
   .page-header { position:sticky; }
 }
 
+@media (max-width:768px) {
+  .page-header {
+    position:static;
+    top:auto;
+  }
+
+  .header {
+    padding:12px 0;
+    gap:12px;
+    flex-wrap:wrap;
+  }
+
+  .brand { flex:1; }
+
+  .header h1 { font-size:18px; }
+
+  .menu-toggle { display:inline-flex; }
+
+  body.menu-enhanced .nav {
+    width:100%;
+    flex-basis:100%;
+    display:none;
+    flex-direction:column;
+    align-items:stretch;
+    gap:10px;
+    padding-top:8px;
+  }
+
+  body.menu-enhanced .nav.is-open {
+    display:flex;
+  }
+
+  body.menu-enhanced .nav .btn {
+    width:100%;
+  }
+}
+
 @media (max-width:640px) {
   main { gap:72px; padding:32px 0 90px; }
-  .header { flex-direction:column; align-items:flex-start; }
-  .nav { width:100%; justify-content:flex-start; }
+  .header { align-items:center; }
   .hero-logo { width:min(300px, 70vw); }
   .hero-note { flex-direction:column; align-items:flex-start; }
   .hero-steps li { align-items:flex-start; }


### PR DESCRIPTION
## Summary
- add a language toggle button and tag markup with translation keys to localize all visible copy
- implement a client-side i18n manager with Google Translate fallback and a configurable `lang-config.js` for manual Arabic overrides
- update styling for the new toggle and right-to-left layouts when Arabic is active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df472fc3808324be49870c767124a2